### PR TITLE
Support all UTF8 characters when converting json to output files

### DIFF
--- a/transcribe-cli/ms_json_to_caption.py
+++ b/transcribe-cli/ms_json_to_caption.py
@@ -298,7 +298,7 @@ def main():
     
         captions = captioner.process_ms_json(json_results)
     
-        with open(caption_file, 'w') as out_file:
+        with open(caption_file, 'w', encoding='utf-8') as out_file:
             out_file.write(captions)
     sys.exit(0)
    


### PR DESCRIPTION
If the recognized json file has non-ASCII characters, the saved txt, srt or vtt files can't show them properly.
This fix makes sure the saved file uses utf8 encoding and show all characters properly.